### PR TITLE
Fix spawns in and around AkAnon

### DIFF
--- a/server/scripts/bugfixes/bugfixes.sql
+++ b/server/scripts/bugfixes/bugfixes.sql
@@ -6,10 +6,10 @@
 -- Ak'Anon --
 -------------
 
--- Remove A Lesser Minotaur from the Steamfont zone area
+-- Stop A Lesser Minotaur from wandering out of the zoo and appearing at the Steamfont zone line.
 -- Forum bug URL: http://www.projecteq.net/forums/index.php?threads/akanon-a-lesser-minotaur-spawning-in-wrong-place.17355/
--- Temp fix, remove the mino. Longer term fix should be to remove pathgrid and fix spawn location
-UPDATE spawn2 SET enabled=0 WHERE id=72032;
+-- Set pathgrid to off to stop it wandering through walls
+UPDATE spawn2 SET pathgrid=0 WHERE id=72032;
 
 ---------------
 -- Steamfont --
@@ -19,3 +19,14 @@ UPDATE spawn2 SET enabled=0 WHERE id=72032;
 -- Forum bug URL: http://www.projecteq.net/forums/index.php?threads/feddi-dooger-should-be-unique-spawn.17354/
 UPDATE npc_types SET unique_spawn_by_name="1" WHERE id="56158";
 
+--------------------
+----- FACTIONS -----
+--------------------
+
+-------------
+-- Ak'Anon --
+-------------
+
+-- A Lesser Minotaur should be aligned to Ak'Anon Zoo rather than Meldrath
+-- Set faction to Ak'Anon Zoo instead of Meldrath
+UPDATE npc_types SET npc_faction_id=1060 WHERE id=55081;

--- a/server/scripts/bugfixes/bugfixes.sql
+++ b/server/scripts/bugfixes/bugfixes.sql
@@ -1,0 +1,21 @@
+--------------------
+------ SPAWNS ------ 
+--------------------
+
+-------------
+-- Ak'Anon --
+-------------
+
+-- Remove A Lesser Minotaur from the Steamfont zone area
+-- Forum bug URL: http://www.projecteq.net/forums/index.php?threads/akanon-a-lesser-minotaur-spawning-in-wrong-place.17355/
+-- Temp fix, remove the mino. Longer term fix should be to remove pathgrid and fix spawn location
+UPDATE spawn2 SET enabled=0 WHERE id=72032;
+
+---------------
+-- Steamfont --
+---------------
+
+-- Make Feddi Dooger a unique spawn
+-- Forum bug URL: http://www.projecteq.net/forums/index.php?threads/feddi-dooger-should-be-unique-spawn.17354/
+UPDATE npc_types SET unique_spawn_by_name="1" WHERE id="56158";
+


### PR DESCRIPTION
Add Lesser Minotaur to AkAnon Zoo faction instead of Meldrath.
Stop Lesser Minotaur from wandering through ceiling to the Steamfont zone line. 
Make Feddi Dooger a unique spawn to prevent him spawning multiple times.